### PR TITLE
Restore declaration of documents, refs #16

### DIFF
--- a/bcnlp_tm.py
+++ b/bcnlp_tm.py
@@ -37,7 +37,7 @@ logging.basicConfig(filename= 'bcnlp_tm_warning.log', level=logging.WARNING)
 
 
 cfg_image = {}
-#documents = []
+documents = []
 
 class BnTopicModel():
 


### PR DESCRIPTION
Uncommenting the declaration of the documents variable appears to resolve the issue of --infile not working, although there may be a better way.